### PR TITLE
Include the config file for ldap backend

### DIFF
--- a/backend/ldap/ldap.php
+++ b/backend/ldap/ldap.php
@@ -11,6 +11,9 @@
 * Copyright 2012 Jean-Louis Dupond
 ************************************************/
 
+// config file
+require_once("backend/ldap/config.php");
+
 include_once('lib/default/diffbackend/diffbackend.php');
 
 class BackendLDAP extends BackendDiff {


### PR DESCRIPTION
ldap.php requires config variables from the config.php but this file doesn't include anywhere.
