### PR TITLE
fix(mimeDecode): use input encoding on failed detection

### DIFF
--- a/include/mimeDecode.php
+++ b/include/mimeDecode.php
@@ -806,7 +806,11 @@ class Mail_mimeDecode
             $mb_order = array_merge(array($supposed_encoding), mb_detect_order());
             set_error_handler('Mail_mimeDecode::_iconv_notice_handler');
             try {
-                $input_converted = iconv(mb_detect_encoding($input, $mb_order, true), $this->_charset, $input);
+                $detected_encoding = mb_detect_encoding($input, $mb_order, true);
+                if ($detected_encoding === false) {
+                    $detected_encoding = $supposed_encoding;
+                }
+                $input_converted = iconv($detected_encoding, $this->_charset, $input);
             }
             catch(Exception $ex) {
                 $this->raiseError($ex->getMessage());

--- a/testing/samples/messages/m0019.txt
+++ b/testing/samples/messages/m0019.txt
@@ -1,0 +1,3 @@
+Date: Sat, 28 Feb 2015 22:32:35 +0100
+MIME-Version: 1.0
+Subject: =?windows-1252?Q?Te=E9st?=


### PR DESCRIPTION
The mb_detect_encoding() call can return false if detection failed. This happens when $supposed_encoding is 'Windows-1252' or 'Windows-1251' because these are only detected when *all* characters are high-byte.

Some details about this can be found in this PHP bug report:
https://bugs.php.net/bug.php?id=64667