### PR TITLE
fix(z_carddav): treat HTTP 401 as invalid authentication

### DIFF
--- a/include/z_carddav.php
+++ b/include/z_carddav.php
@@ -546,7 +546,6 @@ EOFXMLGETXMLVCARD;
         switch($result['http_code']) {
             case 200:
             case 207:
-            case 401:
                 $status = true;
                 break;
         }


### PR DESCRIPTION
BackendCardDAV needs this because it calls carddav_backend::set_auth() before calling cardav_backend::check_connection(). These two calls in succession effectively validate the user's credentials, so a HTTP 401 Unauthorized response status should not be treated as a valid authentication. Without this change, BackendCardDAV will throw on ::discoverAddressbooks().

Alternate solution: catch the unauthorized status in the first call we execute from BackendCardDAV, which would be ::discoverAddressbooks().