### PR TITLE
BackendCombined - support username mapping

### DIFF
--- a/backend/combined/combined.php
+++ b/backend/combined/combined.php
@@ -100,6 +100,8 @@ class BackendCombined extends Backend implements ISearchProvider {
             $u = $username;
             $d = $domain;
             $p = $password;
+
+            // Apply mapping from configuration
             if(isset($this->config['backends'][$i]['users'])){
                 if(!isset($this->config['backends'][$i]['users'][$username])){
                     unset($this->backends[$i]);
@@ -112,6 +114,15 @@ class BackendCombined extends Backend implements ISearchProvider {
                 if(isset($this->config['backends'][$i]['users'][$username]['domain']))
                     $d = $this->config['backends'][$i]['users'][$username]['domain'];
             }
+
+            // Apply username mapping from state backend
+            if (isset($this->config['usemapping']) && $this->config['usemapping']) {
+                $mappedUsername = ZPush::GetStateMachine()->GetMappedUsername($u, strtolower($this->config['backends'][$i]['name']));
+                if ($mappedUsername !== null) {
+                    $u = $mappedUsername;
+                }
+            }
+
             if($this->backends[$i]->Logon($u, $d, $p) == false){
                 ZLog::Write(LOGLEVEL_DEBUG, sprintf("Combined->Logon() failed on %s ", $this->config['backends'][$i]['name']));
                 return false;

--- a/backend/combined/config.php
+++ b/backend/combined/config.php
@@ -109,6 +109,8 @@ class BackendCombinedConfig {
             ),
             //creating a new folder in the root folder should create a folder in one backend
             'rootcreatefolderbackend' => 'i',
+            //enable to use username mapping for the different backends
+            'usemapping' => false,
         );
     }
 }

--- a/lib/core/zpush.php
+++ b/lib/core/zpush.php
@@ -336,7 +336,7 @@ class ZPush {
      * @access public
      * @throws FatalNotImplementedException
      * @throws HTTPReturnCodeException
-     * @return object   implementation of IStateMachine
+     * @return IStateMachine
      */
     static public function GetStateMachine() {
         if (!isset(ZPush::$stateMachine)) {

--- a/lib/interface/istatemachine.php
+++ b/lib/interface/istatemachine.php
@@ -194,6 +194,37 @@ interface IStateMachine {
      * @return array(mixed)
      */
     public function GetAllStatesForDevice($devid);
+
+    /**
+     * Retrieves the mapped username for a specific username and backend.
+     *
+     * @param string $username The username to lookup
+     * @param string $backend Name of the backend to lookup
+     *
+     * @return string The mapped username or null if none found
+     */
+    public function GetMappedUsername($username, $backend);
+
+    /**
+     * Maps a username for a specific backend to another username.
+     *
+     * @param string $username The username to map
+     * @param string $backend Name of the backend
+     * @param string $mappedname The mappend username
+     *
+     * @return boolean
+     */
+    public function MapUsername($username, $backend, $mappedname);
+
+    /**
+     * Unmaps a username for a specific backend.
+     *
+     * @param string $username The username to unmap
+     * @param string $backend Name of the backend
+     *
+     * @return boolean
+     */
+    public function UnmapUsername($username, $backend);
 }
 
 ?>

--- a/lib/utils/zpushadmin.php
+++ b/lib/utils/zpushadmin.php
@@ -617,6 +617,42 @@ class ZPushAdmin {
         return array($processed, $deleted);
     }
 
+    /**
+     * Maps a username for a specific backend to another username.
+     *
+     * @param string $user The username
+     * @param string $backend Name of the backend to map
+     * @param string $targetUsername The username to actually use for this backend
+     *
+     * @return boolean
+     */
+    static public function AddUsernameMapping($user, $backend, $targetUsername) {
+        if (!ZPush::GetStateMachine()->MapUsername($user, $backend, $targetUsername)) {
+            ZLog::Write(LOGLEVEL_ERROR, sprintf("ZPushAdmin::AddUsernameMapping(): unable to add mapping for user %s and backend %s", $user, $backend));
+            return false;
+        }
+
+        ZLog::Write(LOGLEVEL_INFO, sprintf("ZPushAdmin::AddUsernameMapping(): successfully mapped user %s and backend %s to username %s", $user, $backend, $targetUsername));
+        return true;
+    }
+
+    /**
+     * Unmaps a username for a specific backend.
+     *
+     * @param string $user The username
+     * @param string $backend Name of the backend to unmap
+     *
+     * @return boolean
+     */
+    static public function RemoveUsernameMapping($user, $backend) {
+        if (!ZPush::GetStateMachine()->UnmapUsername($user, $backend)) {
+            ZLog::Write(LOGLEVEL_ERROR, sprintf("ZPushAdmin::RemoveUsernameMapping(): unable to remove mapping for user %s and backend %s", $user, $backend));
+            return false;
+        }
+
+        ZLog::Write(LOGLEVEL_INFO, sprintf("ZPushAdmin::RemoveUsernameMapping(): successfully unmapped user %s and backend %s", $user, $backend));
+        return true;
+    }
 }
 
 ?>

--- a/sql/mysql.sql
+++ b/sql/mysql.sql
@@ -17,3 +17,12 @@ create table zpush_preauth_users (id integer auto_increment, username varchar(50
             created_at datetime not null, updated_at datetime not null, primary key (id));
 
 create unique index index_zpush_preauth_users_on_username_and_device_id on zpush_preauth_users (username, device_id);
+
+create table zpush_combined_usermap (
+  username varchar(50) not null,
+  backend varchar(32) not null,
+  mappedname varchar(200) not null,
+  created_at datetime not null,
+  updated_at datetime not null,
+  primary key (username, backend)
+);


### PR DESCRIPTION
This adds username mapping configuration support to the state machine, which can optionally be used by BackendCombined to transform the username as entered by the user into another username based on which sub-backend is being talked to.

Only username transformations are supported, as opposed to the mapping supported in the configuration which supports username, password and domain transformation.

Mappings are created and removed by z-push-admin. The full name of the backend is used. Command examples:

```
  ./z-push-admin.php -a ...
      map -u username@domain.tld -b BackendIMAP -t username_domain
      map -u username@domain.tld -b BackendCalDAV -t other_user_name
      unmap -u username@domain.tld -b BackendIMAP
```

Use case: I have a number of users that connect through the combined backend with their IMAP, CalDAV and CardDAV services. These last two are served by OwnCloud, which allows users to change their password but not their username. There are a number of other systems out there which make it difficult to change usernames, and a simple username transformation mapping as proposed by this commit would have been immensely useful.

This mapping does require that all the user's passwords are identical across all backends as I'm not planning on storing my users' passwords in the configuration for obvious reasons. However, this could be further expanded with a "domain" mapping.