### PR TITLE
CalDAV fixes

### DIFF
--- a/backend/caldav/caldav.php
+++ b/backend/caldav/caldav.php
@@ -55,16 +55,13 @@ class BackendCalDAV extends BackendDiff {
     private $_caldav;
     private $_caldav_path;
     private $_collection = array();
-    private $_username;
 
     private $changessinkinit;
     private $sinkdata;
     private $sinkmax;
 
-
     /**
      * Constructor
-     *
      */
     public function BackendCalDAV() {
         if (!function_exists("curl_init")) {
@@ -81,7 +78,6 @@ class BackendCalDAV extends BackendDiff {
      * @see IBackend::Logon()
      */
     public function Logon($username, $domain, $password) {
-        $this->_username = $username;
         $this->_caldav_path = str_replace('%u', $username, CALDAV_PATH);
         $this->_caldav = new CalDAVClient(CALDAV_SERVER . ":" . CALDAV_PORT . $this->_caldav_path, $username, $password);
         if ($connected = $this->_caldav->CheckConnection()) {
@@ -699,7 +695,6 @@ class BackendCalDAV extends BackendDiff {
                             $body = Utils::Utf8_truncate($body, $truncsize);
                             $message->bodytruncated = 1;
                         } else {
-                            $body = $body;
                             $message->bodytruncated = 0;
                         }
                         $body = str_replace("\n","\r\n", str_replace("\r","",$body));
@@ -741,7 +736,7 @@ class BackendCalDAV extends BackendDiff {
         // Workaround #127 - No organizeremail defined
         if (!isset($message->organizeremail)) {
             ZLog::Write(LOGLEVEL_DEBUG, sprintf("BackendCalDAV->_ParseVEventToSyncObject(): No organizeremail defined, using username"));
-            $message->organizeremail = $this->_username;
+            $message->organizeremail = $this->originalUsername;
         }
 
         $valarm = current($event->GetComponents("VALARM"));
@@ -1022,7 +1017,7 @@ class BackendCalDAV extends BackendDiff {
             //Some phones doesn't send the organizeremail, so we gotto get it somewhere else.
             //Lets use the login here ($username)
             if (!isset($data->organizeremail)) {
-                $vevent->AddProperty("ORGANIZER", sprintf("MAILTO:%s", $this->_username));
+                $vevent->AddProperty("ORGANIZER", sprintf("MAILTO:%s", $this->originalUsername));
             }
             foreach ($data->attendees as $att) {
                 $att_str = sprintf("MAILTO:%s", $att->email);

--- a/backend/combined/combined.php
+++ b/backend/combined/combined.php
@@ -123,10 +123,11 @@ class BackendCombined extends Backend implements ISearchProvider {
                 }
             }
 
-            if($this->backends[$i]->Logon($u, $d, $p) == false){
+            if ($this->backends[$i]->Logon($u, $d, $p) == false) {
                 ZLog::Write(LOGLEVEL_DEBUG, sprintf("Combined->Logon() failed on %s ", $this->config['backends'][$i]['name']));
                 return false;
             }
+            $this->backends[$i]->SetOriginalUsername($username);
         }
 
         ZLog::Write(LOGLEVEL_DEBUG, "Combined->Logon() success");

--- a/lib/default/backend.php
+++ b/lib/default/backend.php
@@ -58,6 +58,7 @@
 abstract class Backend implements IBackend {
     protected $permanentStorage;
     protected $stateStorage;
+    protected $originalUsername;
 
     /**
      * Constructor
@@ -301,5 +302,18 @@ abstract class Backend implements IBackend {
         }
     }
 
+    /**
+     * Sets the username originally specified by the user to connect with Z-Push. This can be different from the
+     * username used for this backend; for example, BackendCombined could have applied a username mapping.
+     *
+     * This information can be used by backends to communicate the right username; for example, calendar events
+     * without an organizer need to supply the original username in order for the device to understand that the
+     * user owns the event.
+     *
+     * @param string $originalUsername The original username
+     */
+    public function SetOriginalUsername($originalUsername) {
+        $this->originalUsername = $originalUsername;
+    }
 }
 ?>


### PR DESCRIPTION
This PR contains two fixes:

1. Prevent 'undefined index' errors when syncing calendars using iOS devices (not sure if it's specific to iOS). These happened a _lot_ and filled the logs with useless information.
2. Fix calendar event organizer when using the "username mapping" feature of BackendCombined (either through the config file or the new state machine mapping). If the organizer was absent, the username used to connect the CalDAV backend with is used instead of the username as supplied by the user. At least iOS requires this username to be identical to the one used to connect to Z-Push with, otherwise it will render the event as an invite instead of an "owned" event.