### PR TITLE
Improve a number of PHPDoc references (@return, @var)

### DIFF
--- a/backend/caldav/caldav.php
+++ b/backend/caldav/caldav.php
@@ -52,6 +52,9 @@ include_once('include/z_RTF.php');
 include_once('include/iCalendar.php');
 
 class BackendCalDAV extends BackendDiff {
+    /**
+     * @var CalDAVClient
+     */
     private $_caldav;
     private $_caldav_path;
     private $_collection = array();

--- a/backend/carddav/carddav.php
+++ b/backend/carddav/carddav.php
@@ -52,6 +52,9 @@ class BackendCardDAV extends BackendDiff implements ISearchProvider {
     private $domain = '';
     private $username = '';
     private $url = null;
+    /**
+     * @var carddav_backend
+     */
     private $server = null;
     private $default_url = null;
     private $gal_url = null;

--- a/backend/combined/combined.php
+++ b/backend/combined/combined.php
@@ -59,7 +59,13 @@ require_once("backend/combined/exporter.php");
 
 class BackendCombined extends Backend implements ISearchProvider {
     public $config;
+    /**
+     * @var IBackend[]
+     */
     public $backends;
+    /**
+     * @var IBackend
+     */
     private $activeBackend;
     private $activeBackendID;
     private $numberChangesSink;

--- a/backend/combined/exporter.php
+++ b/backend/combined/exporter.php
@@ -47,8 +47,14 @@
  */
 
 class ExportChangesCombined implements IExportChanges {
+    /**
+     * @var BackendCombined
+     */
     private $backend;
     private $syncstates;
+    /**
+     * @var IExportChanges[]
+     */
     private $exporters;
     private $importer;
     private $importwraps;

--- a/backend/imap/imap.php
+++ b/backend/imap/imap.php
@@ -2254,7 +2254,7 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
      * @param string        $receiveddate   a date as a string
      *
      * @access protected
-     * @return string
+     * @return integer
      */
     protected function cleanupDate($receiveddate) {
         if (is_array($receiveddate)) {

--- a/lib/core/zpush.php
+++ b/lib/core/zpush.php
@@ -387,7 +387,7 @@ class ZPush {
      * @param boolean   $initialize     (opt) default true: initializes the DeviceManager if not already done
      *
      * @access public
-     * @return object DeviceManager
+     * @return DeviceManager
      */
     static public function GetDeviceManager($initialize = true) {
         if (!isset(ZPush::$deviceManager) && $initialize)


### PR DESCRIPTION
These few fixes and additions can help new developers by aiding their IDE's code completion features. For example, PHPStorm understands the "ClassName" and "ClassName[]" references and correctly displays the appropriate methods and variables when accessing those members.