### PR TITLE
IMAP email date improvements

### DIFF
--- a/backend/imap/imap.php
+++ b/backend/imap/imap.php
@@ -2260,13 +2260,13 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
             // Header Date could be repeated in the message, we only check the first
             $receiveddate = $receiveddate[0];
         }
-        $receiveddate = strtotime(preg_replace("/\\(.*\\)/", "", $receiveddate));
-        if ($receiveddate == false || $receiveddate == -1) {
-            ZLog::Write(LOGLEVEL_WARN, "cleanupDate() : Received date is false. Message might be broken.");
+        $receivedtime = strtotime(preg_replace("/\\(.*\\)/", "", $receiveddate));
+        if ($receivedtime == false || $receivedtime == -1) {
+            ZLog::Write(LOGLEVEL_WARN, sprintf("cleanupDate('%s'): strtotime() failed - message might be broken.", $receiveddate));
             return null;
         }
 
-        return $receiveddate;
+        return $receivedtime;
     }
 
     /**

--- a/backend/imap/imap.php
+++ b/backend/imap/imap.php
@@ -1318,14 +1318,14 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
      * @return array/boolean
      */
     public function StatMessage($folderid, $id) {
-        ZLog::Write(LOGLEVEL_DEBUG, sprintf("BackendIMAP->StatMessage('%s','%s')", $folderid,  $id));
+        ZLog::Write(LOGLEVEL_DEBUG, sprintf("BackendIMAP->StatMessage('%s','%s')", $folderid, $id));
         $folderImapid = $this->getImapIdFromFolderId($folderid);
 
         $this->imap_reopen_folder($folderImapid);
         $overview = @imap_fetch_overview( $this->mbox , $id , FT_UID);
 
         if (!$overview) {
-            ZLog::Write(LOGLEVEL_WARN, sprintf("BackendIMAP->StatMessage('%s','%s'): Failed to retrieve overview: %s", $folderid,  $id, imap_last_error()));
+            ZLog::Write(LOGLEVEL_WARN, sprintf("BackendIMAP->StatMessage('%s','%s'): Failed to retrieve overview: %s", $folderid, $id, imap_last_error()));
             return false;
         }
 
@@ -1497,7 +1497,6 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
         else {
             throw new StatusException(sprintf("BackendIMAP->DeleteMessage(): Message is outside the sync range"), SYNC_STATUS_OBJECTNOTFOUND);
         }
-
 
         return ($s1 && $s2 && $s11);
     }
@@ -2261,7 +2260,7 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
             // Header Date could be repeated in the message, we only check the first
             $receiveddate = $receiveddate[0];
         }
-        $receiveddate = strtotime(preg_replace("/\(.*\)/", "", $receiveddate));
+        $receiveddate = strtotime(preg_replace("/\\(.*\\)/", "", $receiveddate));
         if ($receiveddate == false || $receiveddate == -1) {
             ZLog::Write(LOGLEVEL_DEBUG, "cleanupDate() : Received date is false. Message might be broken.");
             return null;

--- a/backend/imap/imap.php
+++ b/backend/imap/imap.php
@@ -2262,7 +2262,7 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
         }
         $receiveddate = strtotime(preg_replace("/\\(.*\\)/", "", $receiveddate));
         if ($receiveddate == false || $receiveddate == -1) {
-            ZLog::Write(LOGLEVEL_DEBUG, "cleanupDate() : Received date is false. Message might be broken.");
+            ZLog::Write(LOGLEVEL_WARN, "cleanupDate() : Received date is false. Message might be broken.");
             return null;
         }
 

--- a/backend/imap/imap.php
+++ b/backend/imap/imap.php
@@ -930,12 +930,18 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
             return $messages;
         }
 
-        foreach($overviews as $overview) {
-            $date = "";
-            if (isset($overview->date)) {
-                // message is out of range for cutoffdate, ignore it
-                if ($this->cleanupDate($overview->date) < $cutoffdate) continue;
-                $date = $overview->date;
+        foreach ($overviews as $overview) {
+            // Determine the message's date and apply the cutoff; if the overview's ->udate property is
+            // not available, fall back to the "Date:" header as it appears in the email.
+            $date = 0;
+            if (isset($overview->udate)) {
+                $date = $overview->udate;
+            } else if (isset($overview->date)) {
+                $date = $this->cleanupDate($overview->date);
+            }
+            if ($date < $cutoffdate) {
+                // Message is out of range; ignore it
+                continue;
             }
 
             // cut of deleted messages
@@ -1322,7 +1328,7 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
         $folderImapid = $this->getImapIdFromFolderId($folderid);
 
         $this->imap_reopen_folder($folderImapid);
-        $overview = @imap_fetch_overview( $this->mbox , $id , FT_UID);
+        $overview = @imap_fetch_overview($this->mbox, $id, FT_UID);
 
         if (!$overview) {
             ZLog::Write(LOGLEVEL_WARN, sprintf("BackendIMAP->StatMessage('%s','%s'): Failed to retrieve overview: %s", $folderid, $id, imap_last_error()));
@@ -1333,7 +1339,13 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
         if (empty($overview[0]->uid)) return false;
 
         $entry = array();
-        $entry["mod"] = isset($overview[0]->date) ? $overview[0]->date : "";
+        if (isset($overview[0]->udate)) {
+            $entry["mod"] = $overview[0]->udate;
+        } else if (isset($overview[0]->date)) {
+            $entry["mod"] = $this->cleanupDate($overview[0]->date);
+        } else {
+            $entry["mod"] = 0;
+        }
         $entry["id"] = $overview[0]->uid;
 
         // 'seen' aka 'read'


### PR DESCRIPTION
These are a number of changes leading up to the introduction of ->udate, a useful property given to us by imap_fetch_overview(). This solved a lot of problems I had using Z-Push-contrib with (old) emails containing broken date headers, giving me *lots* of `cleanupDate` errors in the logs and issues with syncing those emails.