### PR TITLE
Fix "Undefined index" warnings using CalDAV backend

### DIFF
--- a/include/z_caldav.php
+++ b/include/z_caldav.php
@@ -8,7 +8,7 @@
 * caldav-client-v2.php by xbgmsharp <xbgmsharp@gmail.com>.
 *
 * Copyright Andrew McMillan (original caldav-client-v2.php), Jean-Louis Dupond (cURL code), xbgmsharp (bugfixes)
-* Copyright Thorsten Köster
+* Copyright Thorsten KÃ¶ster
 * License   GNU LGPL version 3 or later (http://www.gnu.org/licenses/lgpl-3.0.txt)
 */
 

--- a/include/z_caldav.php
+++ b/include/z_caldav.php
@@ -931,8 +931,9 @@ EOFILTER;
             $this->SetCalendar($relative_url);
         }
 
+        $hasToken = !$initial && isset($this->synctoken[$this->calendar_url]);
         if ($support_dav_sync) {
-            $token = ($initial ? "" : $this->synctoken[$this->calendar_url]);
+            $token = ($hasToken ? $this->synctoken[$this->calendar_url] : "");
 
             $body = <<<EOXML
 <?xml version="1.0" encoding="utf-8"?>
@@ -993,6 +994,12 @@ EOXML;
                     break;
             }
         }
+
+        // Report sync-token support on initial sync
+        if ($initial && $support_dav_sync && !isset($this->synctoken[$this->calendar_url])) {
+            ZLog::Write(LOGLEVEL_WARN, sprintf('CalDAVClient::GetSync(): no DAV::sync-token received; did you set CALDAV_SUPPORTS_SYNC correctly?'));
+        }
+
         return $report;
     }
 


### PR DESCRIPTION
I had set CALDAV_SUPPORTS_SYNC incorrectly (using SabreDAV 1.8.6 instead of the supported 1.9+) and CalDAVClient err'ed on me when it tried to access its sync tokens, which it of course did not have.

This adds a clear warning message informing the user of a possible fix and prevents the "Undefined index" warnings from occurring by checking if a token is available.

Quite possibly fixes issue #139.

The UTF-8 fix makes the commit diff human readable by github. :-)