### PR TITLE
Improve logging output for counts

### DIFF
--- a/lib/default/diffbackend/exportchangesdiff.php
+++ b/lib/default/diffbackend/exportchangesdiff.php
@@ -110,7 +110,7 @@ class ExportChangesDiff extends DiffState implements IExportChanges{
             $this->changes = $this->getDiffTo($folderlist);
         }
 
-        ZLog::Write(LOGLEVEL_INFO, sprintf("ExportChangesDiff->InitializeExporter(): Found '%d' changes", count($this->changes) ));
+        ZLog::Write(LOGLEVEL_INFO, sprintf("ExportChangesDiff->InitializeExporter(): Found %d changes", count($this->changes)));
     }
 
     /**

--- a/lib/request/sync.php
+++ b/lib/request/sync.php
@@ -465,7 +465,7 @@ class Sync extends RequestProcessor {
                         }
 
                         if ($status == SYNC_STATUS_SUCCESS && $this->importer !== false) {
-                            ZLog::Write(LOGLEVEL_INFO, sprintf("Processed '%d' incoming changes", $nchanges));
+                            ZLog::Write(LOGLEVEL_INFO, sprintf("Sync->Handle(): Processed %d incoming changes", $nchanges));
                             if (!$actiondata["fetchids"])
                                 self::$topCollector->AnnounceInformation(sprintf("%d incoming", $nchanges), true);
 


### PR DESCRIPTION
Wherever counts are shown, the number should not be quoted. This might
seem to indicate that it's a string we're showing.

Also add logging location to Sync logging of incoming changes.