### PR TITLE
Fix charset conversion of binary data for PHP < 5.4

### DIFF
--- a/include/mimeDecode.php
+++ b/include/mimeDecode.php
@@ -809,16 +809,15 @@ class Mail_mimeDecode
                     $detected_encoding = $supposed_encoding;
                 }
                 $input_converted = iconv($detected_encoding, $this->_charset, $input);
+                if ($input_converted === false || mb_strlen($input_converted, $this->_charset) !== mb_strlen($input, $detected_encoding)) {
+                    ZLog::Write(LOGLEVEL_DEBUG, "Mail_mimeDecode()::_autoconvert_encoding(): Text cannot be correctly decoded, using original text. This will be ok if the part is not text, otherwise expect encoding errors");
+                    $input_converted = $input;
+                }
             }
             catch(Exception $ex) {
                 $this->raiseError($ex->getMessage());
             }
             restore_error_handler();
-
-            if (strlen($input_converted) == 0 && strlen($input) != 0) {
-                ZLog::Write(LOGLEVEL_DEBUG, "Mail_mimeDecode()::_autoconvert_encoding(): Text cannot be correctly decoded, using original text. This will be ok if the part is not text, otherwise expect encoding errors");
-                $input_converted = $input;
-            }
         }
 
         return $input_converted;


### PR DESCRIPTION
There is an issue with the handling of charsets in `include/mimeDecode.php`, specifically `_autoconvert_encoding()`. The function uses `iconv()` to convert data (in this case, a binary PDF) to the required charset, but binary characters often cannot be converted. However, the behaviour of `iconv()` changed in PHP 5.4.0, and this code only works correctly in newer versions.

From the man page:

> PHP 5.4.0: Since this version, the function returns FALSE on illegal characters, unless //IGNORE is specified in output charset. Before, it returned partial output string. 

This is leveraged in `_autoconvert_encoding()` by a check, which returns the original string in case `iconv()` returns a non-string/empty string. However, pre-5.4, `iconv()` will just return as much as it could decode, which passed the checks and resulted in truncated attachments coming back.

This patch checks the multi-byte string length of the converted string, and if it does not match, resets the string to the original. It also handles `false` being returned for newer versions.