### PR TITLE
utils/timezoneutil.php: getMSTZnameFromTZName($name):

### DIFF
--- a/lib/utils/timezoneutil.php
+++ b/lib/utils/timezoneutil.php
@@ -1229,8 +1229,30 @@ class TimezoneUtil {
      */
     static public function getMSTZnameFromTZName($name) {
         foreach (self::$mstzones as $mskey => $msdefs) {
-            if ($name == $msdefs[0])
+            if ($name == $msdefs[0]) {
                 return $msdefs[1];
+            }
+        }
+
+        // Not found? Then retrieve the correct TZName first and try again.
+        // That's ugly and needs a proper fix. But for now this method can convert
+        // - Europe/Berlin
+        // - W Europe Standard Time
+        // to "(GMT+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna" 
+        // which is more correct than the hardcoded default of (GMT+00:00...)
+        $tzName = '';
+        foreach (self::$phptimezones as $tzn => $phptzs) {
+            if (in_array($name, $phptzs)) {
+                $tzName = $tzn;
+                break;
+            }
+        }
+        if ($tzName != '') {
+            foreach (self::$mstzones as $mskey => $msdefs) {
+                if ($tzName == $msdefs[0]) {
+                    return $msdefs[1];
+                }
+            }
         }
 
         ZLog::Write(LOGLEVEL_WARN, sprintf("TimezoneUtil::getMSTZnameFromTZName() no MS name found for '%s'. Returning '(GMT) Greenwich Mean Time: Dublin, Edinburgh, Lisbon, London'", $name));


### PR DESCRIPTION
This PR enables the translation from "Europe/Berlin" and "W Europe Standard Time" to the desired  ActiveSync Format to be able to comply with more AS-Clients (owncloud+blackberry10 in my case).

fixes #236 

The code/flow isn't pretty but gets the job done. feel free to modify to your needs.


Released under the Affero GNU General Public License (AGPL) version 3