### PR TITLE
Workaround for "Timezone issue with calendar sync #236"

### DIFF
--- a/backend/caldav/caldav.php
+++ b/backend/caldav/caldav.php
@@ -606,7 +606,7 @@ class BackendCalDAV extends BackendDiff {
                     break;
 
                 case "DTSTART":
-                    $message->starttime = Utils::MakeUTCDate($property->Value(), Utils::ParseTimezone($property->GetParameterValue("TZID")));
+                    $message->starttime = Utils::MakeUTCDate($property->Value(), $property->GetParameterValue("TZID"));
                     if (strlen($property->Value()) == 8) {
                         $message->alldayevent = "1";
                     }
@@ -634,7 +634,7 @@ class BackendCalDAV extends BackendDiff {
                     break;
 
                 case "DTEND":
-                    $message->endtime = Utils::MakeUTCDate($property->Value(), Utils::ParseTimezone($property->GetParameterValue("TZID")));
+                    $message->endtime = Utils::MakeUTCDate($property->Value(), $property->GetParameterValue("TZID"));
                     if (strlen($property->Value()) == 8) {
                         $message->alldayevent = "1";
                     }

--- a/lib/utils/timezoneutil.php
+++ b/lib/utils/timezoneutil.php
@@ -1255,8 +1255,12 @@ class TimezoneUtil {
             }
         }
 
-        ZLog::Write(LOGLEVEL_WARN, sprintf("TimezoneUtil::getMSTZnameFromTZName() no MS name found for '%s'. Returning '(GMT) Greenwich Mean Time: Dublin, Edinburgh, Lisbon, London'", $name));
-        return self::$mstzones["085"][1];
+	// Timezone '' has to be interpreted as default timezone
+        $servertzname = self::guessTZNameFromPHPName($name);
+        return self::GetFullTZFromTZName($servertzname);
+
+        // ZLog::Write(LOGLEVEL_WARN, sprintf("TimezoneUtil::getMSTZnameFromTZName() no MS name found for '%s'. Returning '(GMT) Greenwich Mean Time: Dublin, Edinburgh, Lisbon, London'", $name));
+        // return self::$mstzones["085"][1];
     }
 
     /**

--- a/lib/utils/timezoneutil.php
+++ b/lib/utils/timezoneutil.php
@@ -1234,6 +1234,12 @@ class TimezoneUtil {
             }
         }
 
+        // '' stands for "Local Time" in Lightning
+        // Use the server default timezone
+        if($name == '') {
+            $name = TIMEZONE;
+        }
+
         // Not found? Then retrieve the correct TZName first and try again.
         // That's ugly and needs a proper fix. But for now this method can convert
         // - Europe/Berlin
@@ -1255,12 +1261,8 @@ class TimezoneUtil {
             }
         }
 
-	// Timezone '' has to be interpreted as default timezone
-        $servertzname = self::guessTZNameFromPHPName($name);
-        return self::GetFullTZFromTZName($servertzname);
-
-        // ZLog::Write(LOGLEVEL_WARN, sprintf("TimezoneUtil::getMSTZnameFromTZName() no MS name found for '%s'. Returning '(GMT) Greenwich Mean Time: Dublin, Edinburgh, Lisbon, London'", $name));
-        // return self::$mstzones["085"][1];
+        ZLog::Write(LOGLEVEL_WARN, sprintf("TimezoneUtil::getMSTZnameFromTZName() no MS name found for '%s'. Returning '(GMT) Greenwich Mean Time: Dublin, Edinburgh, Lisbon, London'", $name));
+        return self::$mstzones["085"][1];
     }
 
     /**


### PR DESCRIPTION
Regarding Ticket #236 Timezone issue with calendar sync

I still got the following error message: 
TimezoneUtil::getMSTZnameFromTZName() no MS name found for ''. Returning '(GMT) Greenwich Mean Time: Dublin, Edinburgh, Lisbon, London'

With the proposed pull-request, the default timezone configured in ./config.php is used. 
