### PR TITLE
Bugfix: Android GMAIL is sending an empty date for searchValueGreate …

### DIFF
--- a/backend/imap/imap.php
+++ b/backend/imap/imap.php
@@ -1985,7 +1985,7 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
         $searchLess = strftime("%Y-%m-%d", strtotime($cpo->GetSearchValueLess()));
 
         $filter = '';
-        if ($searchGreater != '') {
+        if ($cpo->GetSearchValueGreater() != '') {
             $filter .= ' SINCE "' . $searchGreater . '"';
         } else {
             // Only search in sync messages
@@ -2022,7 +2022,7 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
                 $filter .= ' SINCE "' . ($limitdate->format("d M Y")) . '"';
             }
         }
-        if ($searchLess != '') {
+        if ($cpo->GetSearchValueLess() != '') {
             $filter .= ' BEFORE "' . $searchLess . '"';
         }
 


### PR DESCRIPTION
Bugfix: Android GMAIL is sending an empty date for searchValueGreate and less. strftime is converting this emtpy string to 01-01-1970 and the if condition != '' is not firing correct.